### PR TITLE
Fix wrong usart index

### DIFF
--- a/same70/hpl/usart/hpl_usart.c
+++ b/same70/hpl/usart/hpl_usart.c
@@ -808,7 +808,7 @@ static void _usart_set_baud_rate(void *const hw, const uint32_t baud_rate)
 	ASSERT(hw);
 	uint32_t usart_freq, cd = 0, fp = 0, clock_select;
 	bool     over;
-	uint8_t  i = _get_usart_index(hw);
+	uint8_t  i = _usart_get_hardware_index(hw);
 	switch (i) {
 	case 0:
 

--- a/samg55/hpl/usart/hpl_usart.c
+++ b/samg55/hpl/usart/hpl_usart.c
@@ -820,7 +820,7 @@ static void _usart_set_baud_rate(void *const hw, const uint32_t baud_rate)
 	ASSERT(hw);
 	uint32_t usart_freq, cd = 0, fp = 0, clock_select;
 	bool     over;
-	uint8_t  i = _get_usart_index(hw);
+	uint8_t  i = _usart_get_hardware_index(hw);
 	switch (i) {
 	case 0:
 #ifdef CONF_FLEXCOM0_FREQUENCY


### PR DESCRIPTION
I doubt ASF4 is unmaintained, this bug still exist in latest download.